### PR TITLE
Reorg Ownership Part 1

### DIFF
--- a/week2/ownership_p1.md
+++ b/week2/ownership_p1.md
@@ -98,7 +98,7 @@ For now, assume the following:
 * Variables **own** values.
 * Two kinds of variables:
   * Value lives on stack
-  * Value lives elsewhere, _pointer_ to value on stack
+  * Value lives elsewhere
 
 <!-- Speaker note: 
   "Value on stack" => Last week's data types

--- a/week2/ownership_p1.md
+++ b/week2/ownership_p1.md
@@ -99,7 +99,7 @@ For now, assume the following:
   * Stored on the stack
   * Stored somewhere else...
 
-<!-- Speaker note: 
+<!-- Speaker note:
   "Value on stack" => Last week's data types
   "Value lives elsewhere" => Today's focus
 -->
@@ -129,13 +129,33 @@ Every time you see a text like `"Hello, World!"` surrounded by double quotes, th
 
 ```rust
 fn main() {
-    println!("Hello, world!"); // Print a string literal
+    println!("Hello, world!");        // Print a string literal
 
-    let s = "Ferris is our friend"; // Another string literal
+    let s = "Ferris is our friend";   // Store another string literal
 }
 ```
 
 * String literals are stored in a read-only section of the executable
+  * In other words, these strings literals are known at _compile-time_
+
+
+---
+
+
+# Python Strings
+
+Suppose we wanted store a user's input. Python can do this easily!
+
+```python
+username1 = input("Enter a short name: ")     # Could be "Bob"
+username2 = input("Enter a long name: ")      # Could be "Bartholomew"
+
+# Python strings can be any length!
+assert len(username1) == 3 and len(username2) == 11
+```
+
+* In Python, we don't have to know the length of the string beforehand
+* How would we do this in Rust?
 
 
 ---
@@ -143,16 +163,17 @@ fn main() {
 
 # Problem: String Literals are Immutable
 
-Suppose we store user input. Python handles this seamlessly - the string can be any length.
+String literals in Rust must be known at compile-time, so we cannot use them for this type of program.
 
-```python
-username = input("Enter a short name: ")    # Could be "Bob"
-username = input("Enter a long name: ")     # Could be "Bartholomew"
+```rust
+fn main() {
+    let username1: <???> = ask_for_user_input();
+    let username2: <???> = ask_for_user_input();
+}
 ```
 
-How is this handled in Rust?
 * We don't know size of `username` at compile time
-* Our string is _dynamically sized_
+* These string must be _dynamically sized_
 
 
 ---
@@ -160,9 +181,10 @@ How is this handled in Rust?
 
 # The `String` Type
 
-* In addition to string literals, Rust has another string type called `String`
+In addition to string literals, Rust has another string type called `String`.
+
 * `String` manages data allocated on the _heap_
-* For data whose size is unknown at compile time
+* We use `String` for managing string data where we do not know the size of the string at compile-time
 
 <!-- Rust has a lot of string types! -->
 
@@ -195,7 +217,7 @@ println!("{}", s); // This will print `hello, world!`
 
 ---
 
-# Problem: When is it Valid?
+# Problem: When is `String` valid?
 
 * String literals are hardcoded into the executable
   * Always valid ✅
@@ -205,7 +227,7 @@ println!("{}", s); // This will print `hello, world!`
       * Who's responsible for this?
 
 <!--
-String literals are *literally* hardcoded into the executable
+String literals are **literally** hardcoded into the executable
 
 As for `Strings`
 - Must return memory, can't hog memory
@@ -251,10 +273,11 @@ However, we need to pair exactly one `malloc` with exactly one `free`.
 
 # C's Proposal: Manual Memory Management
 
-* Using `malloc` and `free` can lead to all sorts of undefined behavior
-  * Unless you are the perfect developer...
-  * Who _never_ writes a bug...
-  * You're bound to shoot yourself in the foot
+Using `malloc` and `free` can lead to all sorts of undefined behavior.
+
+* Unless you are the perfect developer...
+* Who _never_ writes a bug...
+* You're bound to shoot yourself in the foot
 
 <!-- Because developers who never write bugs definitely exist -_- -->
 

--- a/week2/ownership_p1.md
+++ b/week2/ownership_p1.md
@@ -135,7 +135,7 @@ fn main() {
 }
 ```
 
-* String literals are stored in a read-only section of the executable
+* String literals are stored in a read-only section of the program binary
   * In other words, these strings literals are known at _compile-time_
 
 
@@ -247,11 +247,11 @@ In C, the _programmer_ is responsible for returning memory.
 - `malloc`: request memory from allocator
 - `free`: return memory to allocator
 
-```rust
-
+```c
     {
-        let s = String::from("hello"); // `malloc`
-        free(s);                       // Done with `s`, free it!
+        char *s = (char *) malloc(6); // Allocate memory for `s`
+        strcpy(s, "hello");           // Set `s` to "hello"
+        free(s);                      // Done with `s`, free it!
     }
 ```
 
@@ -296,7 +296,7 @@ In Java, the _runtime_ is responsible for returning memory.
 ---
 
 
-# Rust's Proposal: Prevent at Compilation
+# Rust's Proposal: Compile-Time Memory Safety
 
 In Rust, the _compiler_ is responsible for returning memory.
 
@@ -310,14 +310,15 @@ In Rust, the _compiler_ is responsible for returning memory.
 ---
 
 
-# Rust's Proposal: Prevent at Compilation
+# Rust's Proposal: Compile-Time Memory Safety
 
 Every variable has a _scope_.
 
 ```rust
+
     {
-        let s = "hello";         // s comes into scope
-    }                           // s goes out of scope
+        let s = String::from("hello"); // s comes into scope
+    } // s goes out of scope
 ```
 
 * There are two important points:
@@ -328,7 +329,7 @@ Every variable has a _scope_.
 ---
 
 
-# Rust's Proposal: Prevent at Compilation
+# Rust's Proposal: Compile-Time Memory Safety
 
 Memory is returned once the variable that owns it goes out of scope.
 
@@ -336,12 +337,12 @@ Memory is returned once the variable that owns it goes out of scope.
 
     {
         let s = String::from("hello"); // s comes into scope
-    }                                  // s goes out of scope
+    } // s goes out of scope
 ```
 
 * When `s` comes into scope, it gets memory from the allocator
 * When `s` goes out of scope, its memory is freed
-    * Rust calls the function `drop` on `s` when we reach the closing bracket
+    * Rust automatically calls the function `drop` on `s` when we reach the closing bracket
 
 <!-- This is the RAII pattern in C++ -->
 <!-- This might seem simple, but it has profound implication on the way we write code in Rust -->

--- a/week2/ownership_p1.md
+++ b/week2/ownership_p1.md
@@ -173,7 +173,7 @@ fn main() {
 ```
 
 * We don't know size of `username` at compile time
-* These string must be _dynamically sized_
+* These strings must be _dynamically sized_
 
 
 ---
@@ -224,7 +224,7 @@ println!("{}", s); // This will print `hello, world!`
 * On the other hand, `String`s are dynamically allocated on the _heap_
     * Must request memory from the allocator at _runtime_
     * Must return the memory when we're done using it
-      * Who's responsible for this?
+    * Who's responsible for this?
 
 <!--
 String literals are **literally** hardcoded into the executable
@@ -240,6 +240,20 @@ As for `Strings`
 
 ---
 
+
+# Python and Java's Proposal: Garbage Collection
+
+In Python and Java, the _runtime_ is responsible for managing memory.
+
+* The runtime is a system that provides services while the program runs
+  * Among these services is the garbage collector
+    * The garbage collector finds unused memory and cleans it up
+  * Runtime processes can be inefficient!
+
+
+---
+
+
 # C's Proposal: Manual Memory Management
 
 In C, the _programmer_ is responsible for returning memory.
@@ -248,11 +262,11 @@ In C, the _programmer_ is responsible for returning memory.
 - `free`: return memory to allocator
 
 ```c
-    {
-        char *s = (char *) malloc(6); // Allocate memory for `s`
-        strcpy(s, "hello");           // Set `s` to "hello"
-        free(s);                      // Done with `s`, free it!
-    }
+int main() {
+    char *s = (char *)malloc(sizeof("hello"));  // Allocate memory for `s`
+    strcpy(s, "hello");                         // Set `s` to "hello"
+    free(s);                                    // Done with `s`, free it!
+}
 ```
 
 ---
@@ -260,7 +274,7 @@ In C, the _programmer_ is responsible for returning memory.
 
 # C's Proposal: Manual Memory Management
 
-However, we need to pair exactly one `malloc` with exactly one `free`.
+However, the programmer must pair exactly one `malloc` with exactly one `free`.
 
 * If we forget to `free`, we leak memory
 * If we `free` too early, we have an invalid variable
@@ -271,26 +285,15 @@ However, we need to pair exactly one `malloc` with exactly one `free`.
 ---
 
 
-# C's Proposal: Manual Memory Management
+# C's Proposal: Memory Footgun
 
 Using `malloc` and `free` can lead to all sorts of undefined behavior.
 
 * Unless you are the perfect developer...
 * Who _never_ writes a bug...
-* You're bound to shoot yourself in the foot
+* You're bound to shoot yourself in the foot!
 
 <!-- Because developers who never write bugs definitely exist -_- -->
-
-
----
-
-# Java's Proposal: Runtime Garbage Collection
-
-In Java, the _runtime_ is responsible for returning memory.
-
-* **Runtime**: system that provides services during the running of a program
-  * Among these services is the garbage collector
-  * However, runtime processes are inefficient
 
 
 ---
@@ -315,13 +318,12 @@ In Rust, the _compiler_ is responsible for returning memory.
 Every variable has a _scope_.
 
 ```rust
-
-    {
-        let s = String::from("hello"); // s comes into scope
-    } // s goes out of scope
+{
+    let s = String::from("hello"); // s comes into scope
+} // s goes out of scope
 ```
 
-* There are two important points:
+* There are two important points here:
     * When `s` comes _into_ scope, it is valid
     * When `s` goes _out_ of scope, it is invalid
 
@@ -334,10 +336,9 @@ Every variable has a _scope_.
 Memory is returned once the variable that owns it goes out of scope.
 
 ```rust
-
-    {
-        let s = String::from("hello"); // s comes into scope
-    } // s goes out of scope
+{
+    let s = String::from("hello"); // s comes into scope
+} // s goes out of scope
 ```
 
 * When `s` comes into scope, it gets memory from the allocator
@@ -346,6 +347,7 @@ Memory is returned once the variable that owns it goes out of scope.
 
 <!-- This is the RAII pattern in C++ -->
 <!-- This might seem simple, but it has profound implication on the way we write code in Rust -->
+
 
 ---
 


### PR DESCRIPTION
Reordered slides to create a narrative arc. The new sequence introduces ownership rules first, identifying the owner upfront ("variables own values"), which then motivates the problem (heap-allocated strings and their complications) and solution (scoping).

Also trimmed slides for brevity while preserving original phrasing

Before:
1. Review: Scopes
2. String Literals, Strings
3. Ownership Rules
4. "Oh no, Strings are heap-allocated!"
5. Solution: tie to scope
6. Rust's approach

After:
1. Ownership Rules
2. String Literals, Strings
3. "Oh no, Strings are heap-allocated!"
4. Solution: tie to scope
5. Review: Scopes
6. Rust's approach