### PR TITLE
Lecture 7 Revisions

### DIFF
--- a/week7/closures_iterators.md
+++ b/week7/closures_iterators.md
@@ -578,9 +578,7 @@ What do you mean, function _trait_???
 
 # `FnOnce`
 
-All closures implement `FnOnce`, since all closures can be called once.
-
-However, a closure that moves captured values **out** of its body will _only_ implement `FnOnce`, and not `FnMut` or `Fn`:
+A closure that moves captured values **out** of its body will _only_ implement `FnOnce`, and not `FnMut` or `Fn`:
 
 ```rust
 let my_str = String::from("x");
@@ -598,6 +596,8 @@ let consume_and_return = move || my_str; // Returns `my_str`, moving it out of t
 
 
 # `unwrap_or_else`
+
+All closures implement `FnOnce`, since all closures can be called once. This does not mean they can _only_ be called once!
 
 Let's look at the definition of the `unwrap_or_else` method on `Option<T>`.
 

--- a/week7/closures_iterators.md
+++ b/week7/closures_iterators.md
@@ -515,7 +515,7 @@ fn main() {
 
 * Why do we `move` instead of borrow?
   * Our child's `println!` technically only needs an immutable reference to `list`
-* The parent might drop `list` before the child thread runs?
+* The parent might drop `list` before the child thread runs
   * Use after free! ☠️
 
 

--- a/week7/closures_iterators.md
+++ b/week7/closures_iterators.md
@@ -605,6 +605,21 @@ Use case: Writing a task scheduler that runs a job exactly once
 
 All closures implement `FnOnce`, since all closures can be called once. This does not mean they can _only_ be called once!
 
+One example is the `unwrap_or_else` method, which calls a closure if it receives an `Err`.
+
+```rust
+fn count(x: &str) -> usize { x.len() }
+
+Ok(2).unwrap_or_else(count);          // unwrap the value in `Ok`
+Err("foo").unwrap_or_else(count), 3;  // else, compute it from closure `count("foo")`
+```
+
+
+---
+
+
+# `unwrap_or_else`
+
 Let's look at the definition of the `unwrap_or_else` method on `Option<T>`.
 
 ```rust

--- a/week7/closures_iterators.md
+++ b/week7/closures_iterators.md
@@ -605,7 +605,7 @@ Use case: Writing a task scheduler that runs a job exactly once
 
 All closures implement `FnOnce`, since all closures can be called once. This does not mean they can _only_ be called once!
 
-One example is the `unwrap_or_else` method, which calls a closure if it receives an `Err`.
+One example is the `unwrap_or_else` method, which calls a closure if it receives an `Err`:
 
 ```rust
 fn count(x: &str) -> usize { x.len() }
@@ -690,6 +690,8 @@ let mut add_two_to_x = || x += 2;
 add_two_to_x();
 ```
 
+* Use cases: Stateful operations on some shared resource
+  * Imagine `x` were a score on a scoreboard
 * Note that this will not compile without the `mut` in `let mut add_two_to_x`
   * `mut` signals that we are mutating our closure's environment
     * Key idea: how variables within scope at invocation change between calls
@@ -728,7 +730,7 @@ Ferris is happy!
 
 # `FnMut`
 
-Just like in `unwrap_or_else`, we can pass a `FnMut` closure to a function.
+We can pass an `FnMut` closure as an argument to a function.
 
 ```rust
 fn do_twice<F>(mut func: F)
@@ -740,29 +742,26 @@ where
 }
 ```
 
+* Would `do_twice` accept a closure that's exclusively `FnOnce`?
+  * No, because we call our closure twice
+* How about an `Fn` closure?
+  * Yes, next slide
+
 
 ---
 
 
 # `Fn`
 
-Finally, the `Fn` trait is a superset of `FnOnce` and `FnMut`.
-
-```rust
-let double = |x| x * 2; // captures nothing
-
-let mascot = String::from("Ferris");
-let is_mascot = |guess| mascot == guess; // mascot borrowed as immutable
-
-let my_sanity = ();
-let cmu = move || {my_sanity;}; // captures sanity and never gives it back...
-```
+The `Fn` trait is a superset of `FnOnce` and `FnMut`.
 
 * `Fn` applies to closures that:
   * Don't move captured values out of their body
   * Don't mutate captured values
   * Don't capture anything from their environment
 * Can be called more than once without mutating the environment
+* Use case: Stateless operations without side effects
+  * Logging, pretty printing, etc.
 
 <!--
 Use case: Stateless operation without side effects
@@ -772,6 +771,61 @@ Use case: Stateless operation without side effects
 
 ---
 
+
+# `Fn`
+
+`Fn` applies to closures that don't capture anything from their environment:
+
+```rust
+let double = |x| x * 2; // captures nothing
+```
+
+---
+
+# `Fn`
+
+`Fn` also applies to closures that don't mutate captured variables:
+
+```rust
+let mascot = String::from("Ferris");
+let is_mascot = |guess| mascot == guess; // mascot borrowed as immutable
+```
+
+
+---
+
+# `Fn`
+
+Finally, `Fn` applies to closures that don't move captured values out of their body:
+
+```rust
+let my_sanity = ();
+let cmu = move || {my_sanity;}; // captures sanity and never gives it back...
+```
+
+* When is `my_sanity` dropped?
+  * `my_sanity` is _not_ dropped when we call and return from our closure!
+  * It's dropped when our closure goes out of scope
+
+
+---
+
+
+# `Fn`
+
+`my_sanity` is dropped when our closure goes out of scope:
+
+```rust
+fn main() {
+  let my_sanity = ();
+  let cmu = move || {my_sanity;}; // captures sanity and never gives it back...
+}
+```
+
+* Again, to reiterate: `my_sanity` is _not_ dropped when we call and return from our closure!
+
+
+---
 
 # `Fn`
 

--- a/week7/closures_iterators.md
+++ b/week7/closures_iterators.md
@@ -592,9 +592,8 @@ let consume_and_return = move || my_str; // Returns `my_str`, moving it out of t
 * `move` keyword specifies that the closure takes ownership when it's created, _not_ when it's called
 
 <!--
-Use case: Writing a task scheduler that runs a job exactly once
-  The captured variable can be a resource that cannot be reused after the task is complete,
-  like a file handle, a network connection, or a database connection.
+Use case: Transactions that should happen exactly once,
+but the underlying resource can be reused for multiple transactions
 -->
 
 
@@ -831,6 +830,8 @@ fn main() {
 
 
 # `Fn`
+
+The `Fn` trait allows you to define functions that accept other functions as arguments:
 
 ```rust
 fn reduce<F, T>(reducer: F, data: &[T]) -> Option<T>

--- a/week7/closures_iterators.md
+++ b/week7/closures_iterators.md
@@ -591,6 +591,12 @@ let consume_and_return = move || my_str; // Returns `my_str`, moving it out of t
     * Rust never implicitly clones `my_str`, cannot be reused after move
 * `move` keyword specifies that the closure takes ownership when it's created, _not_ when it's called
 
+<!--
+Use case: Writing a task scheduler that runs a job exactly once
+  The captured variable can be a resource that cannot be reused after the task is complete,
+  like a file handle, a network connection, or a database connection.
+-->
+
 
 ---
 
@@ -661,7 +667,7 @@ Now let's observe the function body.
 
 # `FnMut`
 
-Recall that `FnMut` applies to closures that might mutate the captured values.
+`FnMut` applies to closures that might mutate the captured values.
 
 ```rust
 let mut x: usize = 1;
@@ -672,6 +678,12 @@ add_two_to_x();
 * Note that this will not compile without the `mut` in `let mut add_two_to_x`
   * `mut` signals that we are mutating our closure's environment
     * Key idea: how variables within scope at invocation change between calls
+
+<!--
+Use case: Stateful operation to some shared resource
+  The captured variable is some shared resource, like a score on a scoreboard,
+  a message queue, etc.
+-->
 
 
 ---
@@ -736,6 +748,11 @@ let cmu = move || {my_sanity;}; // captures sanity and never gives it back...
   * Don't mutate captured values
   * Don't capture anything from their environment
 * Can be called more than once without mutating the environment
+
+<!--
+Use case: Stateless operation without side effects
+  Example is logging
+-->
 
 
 ---

--- a/week7/closures_iterators.md
+++ b/week7/closures_iterators.md
@@ -248,7 +248,7 @@ let annotated_closure = |num: u32| -> u32 {
 };
 ```
 * This looks very similar to functions we've seen
-* Like normal variables, rust can derive closure type annotations from context!
+* Like normal variables, Rust can derive closure type annotations from context!
 
 
 ---

--- a/week7/closures_iterators.md
+++ b/week7/closures_iterators.md
@@ -498,7 +498,7 @@ println!("Mystery value is {}", mystery(5));
 ---
 
 
-# Thread sneak peek
+# Case for `move`: Thread Safety
 
 Let's briefly explore spawning a new thread with a closure.
 
@@ -513,9 +513,10 @@ fn main() {
 }
 ```
 
-* The `println!` technically only needs an immutable reference to `list`
-* But what would happen if the parent thread dropped `list` before the child thread ran?
-* Use after free! ☠️
+* Why do we `move` instead of borrow?
+  * Our child's `println!` technically only needs an immutable reference to `list`
+* The parent might drop `list` before the child thread runs?
+  * Use after free! ☠️
 
 
 ---

--- a/week7/closures_iterators.md
+++ b/week7/closures_iterators.md
@@ -544,22 +544,7 @@ What do you mean, function _trait_???
   * `FnOnce`
   * `FnMut`
   * `Fn`
-
-
----
-
-
-# The `Fn` traits
-
-
-* `FnOnce` applies to closures that can be called once
-  * If a closure moves captured values out of its body, it can only be called once, thus it implements `FnOnce`
-* `FnMut` applies to closures that might mutate the captured values
-  * These closures can be called more than once
-* `Fn` applies to all other types of closures
-  * Closures that don't move values out
-  * Closures that don't mutate
-  * Closures that don't capture anything
+* You don't `impl` them, they apply to a closure automatically
 
 
 ---
@@ -571,6 +556,22 @@ What do you mean, function _trait_???
 
 * `Fn` is also `FnMut` and `FnOnce`
 * `FnMut` is also `FnOnce`
+
+
+---
+
+
+# The `Fn` traits
+
+![bg right:40% 120%](../images/closure_traits.svg)
+
+* `FnOnce`: Closures that can only be called once
+  * e.g. A closure that moves captured values out of its body
+* `FnMut`: Closures that might mutate the captured values
+  * These closures can be called more than once
+* `Fn`: All the rest
+  * Don't move values out, don't mutate, don't capture anything
+
 
 ---
 

--- a/week7/closures_iterators.md
+++ b/week7/closures_iterators.md
@@ -818,14 +818,17 @@ let cmu = move || {my_sanity;}; // captures sanity and never gives it back...
 ```rust
 fn main() {
   let my_sanity = ();
-  let cmu = move || {my_sanity;}; // captures sanity and never gives it back...
-}
+  let cmu = move || {my_sanity;};
+  cmu(); // `my_sanity` is NOT dropped here
+  cmu(); // `my_sanity` is NOT dropped here
+} // `my_sanity gets dropped here`
 ```
 
 * Again, to reiterate: `my_sanity` is _not_ dropped when we call and return from our closure!
 
 
 ---
+
 
 # `Fn`
 

--- a/week7/closures_iterators.md
+++ b/week7/closures_iterators.md
@@ -565,7 +565,7 @@ What do you mean, function _trait_???
 
 ![bg right:40% 120%](../images/closure_traits.svg)
 
-* `FnOnce`: Closures that can only be called once
+* `FnOnce`: Closures that can be called once
   * e.g. A closure that moves captured values out of its body
 * `FnMut`: Closures that might mutate the captured values
   * These closures can be called more than once
@@ -578,18 +578,20 @@ What do you mean, function _trait_???
 
 # `FnOnce`
 
-Let's look at some examples of `FnOnce`.
+All closures implement `FnOnce`, since all closures can be called once.
+
+However, a closure that moves captured values **out** of its body will _only_ implement `FnOnce`, and not `FnMut` or `Fn`:
 
 ```rust
 let my_str = String::from("x");
-let consume_and_return = move || my_str;
+let consume_and_return = move || my_str; // Returns `my_str`, moving it out of the closure
 ```
 
-* Recall that Rust will never implicitly clone `my_str`
-  * This closure consumes `my_str` by giving ownership back to the caller
-* Closures that can be called once implement `FnOnce`
-* All closures implement this trait, since all closures can be called
-* A closure that moves captured values **out** of its body will _only_ implement `FnOnce`, and not `FnMut` or `Fn`
+* Why can this closure only be called once?
+  * `my_str` is no longer accessible to our closure after it's called!
+  * It takes ownership of `my_str`, then gives ownership back to the caller
+    * Rust never implicitly clones `my_str`, cannot be reused after move
+* `move` keyword specifies that the closure takes ownership when it's created, _not_ when it's called
 
 
 ---

--- a/week7/edit-summary.md
+++ b/week7/edit-summary.md
@@ -1,6 +1,0 @@
-Additions:
-* Provide motivating examples for closures
-    * i.e. when would we want a closure that falls under `FnOnce`, `FnMut`, and `Fn` respectively?
-
-Deletions (if timing is tight):
-* Crates section

--- a/week7/edit-summary.md
+++ b/week7/edit-summary.md
@@ -1,0 +1,6 @@
+Additions:
+* Provide motivating examples for closures
+    * i.e. when would we want a closure that falls under `FnOnce`, `FnMut`, and `Fn` respectively?
+
+Deletions (if timing is tight):
+* Crates section


### PR DESCRIPTION
Additions:
* [[1]](https://github.com/rust-stuco/lectures/pull/67/files#diff-a7c23b83f31b9dfdc8aca81f115138a94cdaf340d05dc13dfec79ae41c44ff24R805-R826) Clarify that captured values are dropped when the closure goes out of scope, not when we call and return from our closure
* [[2]](https://github.com/rust-stuco/lectures/pull/67/files#diff-a7c23b83f31b9dfdc8aca81f115138a94cdaf340d05dc13dfec79ae41c44ff24R592) Why our `FnOnce` closure can't take back ownership after it moves captured values out of its body
* [[3]](https://github.com/rust-stuco/lectures/pull/67/files#diff-a7c23b83f31b9dfdc8aca81f115138a94cdaf340d05dc13dfec79ae41c44ff24R600-R614) Contextualize `unwrap_or_else` before jumping into definition
* [[4]](https://github.com/rust-stuco/lectures/pull/67/files#diff-a7c23b83f31b9dfdc8aca81f115138a94cdaf340d05dc13dfec79ae41c44ff24R594-R597) [[5]](https://github.com/rust-stuco/lectures/pull/67/files#diff-a7c23b83f31b9dfdc8aca81f115138a94cdaf340d05dc13dfec79ae41c44ff24R698-R702) [[6]](https://github.com/rust-stuco/lectures/pull/67/files#diff-a7c23b83f31b9dfdc8aca81f115138a94cdaf340d05dc13dfec79ae41c44ff24R765-R768) Added use cases for each kind of closure

Deletions:
* Crates section can be trimmed to make room for these additions

The rest are smaller cosmetic changes